### PR TITLE
Fix Playwright startup recursion in Windows installer

### DIFF
--- a/src/services/cookies/playwright_bootstrap.py
+++ b/src/services/cookies/playwright_bootstrap.py
@@ -45,6 +45,19 @@ def is_playwright_installed() -> bool:
     return importlib.util.find_spec("playwright") is not None
 
 
+def _playwright_cli_command(*args: str) -> list[str]:
+    """Return a Playwright CLI command that works in normal and frozen builds.
+
+    In a PyInstaller executable, ``sys.executable`` points at MediaDownloader.exe.
+    Running ``sys.executable -m playwright ...`` would recursively launch the app.
+    Playwright ships its own Node driver, so call that directly instead.
+    """
+    from playwright._impl._driver import compute_driver_executable
+
+    node_exe, cli_js = compute_driver_executable()
+    return [str(node_exe), str(cli_js), *args]
+
+
 def is_chromium_installed() -> bool:
     """Check whether Playwright's managed Chromium binary exists on disk.
 
@@ -59,7 +72,7 @@ def is_chromium_installed() -> bool:
         # The canonical way to find it is via the internal registry,
         # but we can also just attempt a lightweight CLI check.
         result = subprocess.run(
-            [sys.executable, "-m", "playwright", "install", "--dry-run", "chromium"],
+            _playwright_cli_command("install", "--dry-run", "chromium"),
             capture_output=True,
             text=True,
             timeout=15,
@@ -166,7 +179,7 @@ def install_chromium_streaming(progress: _InstallProgress) -> None:
         progress.set_phase("Starting Chromium download...")
 
         proc = subprocess.Popen(
-            [sys.executable, "-m", "playwright", "install", "chromium"],
+            _playwright_cli_command("install", "chromium"),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,


### PR DESCRIPTION
## Summary

Fixes a Windows installer smoke-test blocker found on the ARM64 build.

In the frozen PyInstaller app, `sys.executable` points to `MediaDownloader.exe`. The Playwright bootstrap used `sys.executable -m playwright install chromium`, which recursively launched the app instead of running the Playwright CLI. That caused multiple MediaDownloader windows and a Not Responding startup state.

This change uses Playwright's packaged Node driver (`compute_driver_executable`) to run the CLI directly, which works in normal Python and frozen builds.

## Verification

- Local quality gate passed:
- Ruff lint
- Ruff format
- BasedPyright src/tests
- Pytest: 343 passed, 18 skipped

## Context

This is required before UI/download smoke testing the ARM64 installer in Parallels Windows 11 ARM.
