### PR TITLE
hotfix: Windows installer + PyInstaller Tcl/Tk fix (v1.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.1.1 - 2026-06-14
+
+Hotfix release fixing Windows installer and PyInstaller build issues.
+
+### Fixed
+
+- Fixed Windows installer crash: `{app}` constant was expanded before install directory was initialized in `CurPageChanged`
+- Fixed PyInstaller build: added Tcl/Tk runtime hook so tkinter initializes correctly in frozen app
+- Fixed PyInstaller build: bundled Tcl/Tk libraries and CustomTkinter assets properly
+- Fixed PyInstaller build: configured `hookspath` and `runtime_hooks` in spec file
+- Fixed Twitter/X downloader: graceful handling of 404 errors from FixTweet API instead of crashing
+- Fixed Spotify routing: downloads now correctly use SpotifyDownloader instead of accidentally routing through YouTubeDownloader
+- Fixed RadioJavan file download timeout: added `timeout` parameter to `download_file()` for per-service timeout control
+- Fixed SoundCloud and TikTok timeouts: increased defaults and added User-Agent headers to prevent API blocking
+
 ## 1.0.0 - 2026-06-08
 
 ### Added

--- a/hooks/hook-customtkinter.py
+++ b/hooks/hook-customtkinter.py
@@ -1,0 +1,19 @@
+"""PyInstaller hook for CustomTkinter.
+
+Ensures all CustomTkinter assets (themes, fonts, icons) are bundled
+with the frozen application.
+"""
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files(
+    "customtkinter",
+    includes=[
+        "assets/**/*.json",
+        "assets/**/*.otf",
+        "assets/**/*.ttf",
+        "assets/**/*.ico",
+        "assets/**/*.png",
+        "assets/**/*.gif",
+    ],
+)

--- a/hooks/runtime_hook_tcl.py
+++ b/hooks/runtime_hook_tcl.py
@@ -1,0 +1,59 @@
+"""PyInstaller runtime hook for Tcl/Tk initialization.
+
+Sets TCL_LIBRARY and TK_LIBRARY environment variables so the Tcl
+interpreter can find its initialization scripts when running from
+a PyInstaller bundle.
+"""
+
+import os
+import sys
+
+
+def _find_tcl_dirs(base: str) -> tuple[str | None, str | None]:
+    """Search for Tcl/Tk library directories under the given base."""
+    tcl_dir = None
+    tk_dir = None
+
+    for entry in os.listdir(base):
+        lower = entry.lower()
+        full = os.path.join(base, entry)
+        if not os.path.isdir(full):
+            continue
+        if lower.startswith("tcl") and tcl_dir is None:
+            tcl_dir = full
+        elif lower.startswith("tk") and tk_dir is None:
+            tk_dir = full
+
+    return tcl_dir, tk_dir
+
+
+if sys.platform == "win32" and hasattr(sys, "_MEIPASS"):
+    base = sys._MEIPASS
+
+    # Strategy 1: look directly under _MEIPASS
+    tcl_dir, tk_dir = _find_tcl_dirs(base)
+
+    # Strategy 2: look under _MEIPASS/tcl/
+    if tcl_dir is None:
+        tcl_sub = os.path.join(base, "tcl")
+        if os.path.isdir(tcl_sub):
+            tcl_dir, tk_dir = _find_tcl_dirs(tcl_sub)
+
+    # Strategy 3: look under _MEIPASS/tcl8.6 and tk8.6
+    if tcl_dir is None:
+        for name in ("tcl8.6", "tcl8.5"):
+            candidate = os.path.join(base, name)
+            if os.path.isdir(candidate):
+                tcl_dir = candidate
+                break
+    if tk_dir is None:
+        for name in ("tk8.6", "tk8.5"):
+            candidate = os.path.join(base, name)
+            if os.path.isdir(candidate):
+                tk_dir = candidate
+                break
+
+    if tcl_dir is not None:
+        os.environ["TCL_LIBRARY"] = tcl_dir
+    if tk_dir is not None:
+        os.environ["TK_LIBRARY"] = tk_dir

--- a/installer.iss
+++ b/installer.iss
@@ -14,7 +14,7 @@
 ;   /DBUNDLE_CHROMIUM - Indicates Chromium is bundled in the installer
 
 #define MyAppName "Media Downloader"
-#define MyAppVersion "1.0.0"
+#define MyAppVersion "1.1.1"
 #ifndef MyAppArchLabel
 #define MyAppArchLabel "x64"
 #endif
@@ -99,12 +99,12 @@ var
   chromiumBundled: Boolean;
   chromiumPath: String;
 begin
-  // Check if Chromium is bundled in the installer
-  chromiumPath := ExpandConstant('{app}\chromium');
-  chromiumBundled := DirExists(chromiumPath);
-
   if CurPageID = wpFinished then
   begin
+    // Only check for Chromium after install directory is set
+    chromiumPath := ExpandConstant('{app}\chromium');
+    chromiumBundled := DirExists(chromiumPath);
+
     if chromiumBundled then
     begin
       // Chromium is bundled - app is ready immediately

--- a/media_downloader.spec
+++ b/media_downloader.spec
@@ -19,16 +19,29 @@ Environment Variables:
 """
 
 import os
-import sys
-from pathlib import Path
 
 import customtkinter
+import tkinter
 
 block_cipher = None
 
 # Paths
 PROJECT_ROOT = os.path.abspath(".")
 CTK_PATH = os.path.dirname(customtkinter.__file__)
+
+# Collect Tcl/Tk library directories for the runtime hook
+_tcl_data = None
+_tk_data = None
+_tcl_dir = os.path.dirname(tkinter.__file__)
+for _entry in os.listdir(_tcl_dir):
+    _full = os.path.join(_tcl_dir, _entry)
+    if not os.path.isdir(_full):
+        continue
+    _lower = _entry.lower()
+    if _lower.startswith("tcl") and _tcl_data is None:
+        _tcl_data = _full
+    elif _lower.startswith("tk") and _tk_data is None:
+        _tk_data = _full
 
 # Check if we should bundle Chromium
 BUNDLE_CHROMIUM = os.environ.get("BUNDLE_CHROMIUM", "0") == "1"
@@ -37,9 +50,17 @@ BUNDLE_CHROMIUM = os.environ.get("BUNDLE_CHROMIUM", "0") == "1"
 datas = [
     # Bundle the themes directory
     (os.path.join(PROJECT_ROOT, "themes"), "themes"),
-    # CustomTkinter needs its own assets bundled
-    (CTK_PATH, "customtkinter"),
+    # CustomTkinter assets only (fonts, themes, icons)
+    (os.path.join(CTK_PATH, "assets"), "customtkinter/assets"),
 ]
+
+# Bundle Tcl/Tk libraries
+if _tcl_data and os.path.isdir(_tcl_data):
+    print(f"[PyInstaller] Bundling Tcl library: {_tcl_data}")
+    datas.append((_tcl_data, "tcl"))
+if _tk_data and os.path.isdir(_tk_data):
+    print(f"[PyInstaller] Bundling Tk library: {_tk_data}")
+    datas.append((_tk_data, "tk"))
 
 # Check for ffmpeg - bundle it if available
 FFMPEG_PATH = os.path.join(PROJECT_ROOT, "bin", "ffmpeg.exe")
@@ -170,9 +191,9 @@ a = Analysis(
         "queue",
         "logging",
     ],
-    hookspath=[],
+    hookspath=["hooks"],
     hooksconfig={},
-    runtime_hooks=[],
+    runtime_hooks=["hooks/runtime_hook_tcl.py"],
     excludes=[
         # Exclude dev/test dependencies
         "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "media-downloader"
-version = "1.0.0"
+version = "1.1.1"
 description = "A cross-platform media downloader supporting YouTube, Spotify, TikTok, Instagram, Twitter, Pinterest, SoundCloud, and RadioJavan"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -505,7 +505,7 @@ wheels = [
 
 [[package]]
 name = "media-downloader"
-version = "1.0.0"
+version = "1.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Fixes

- Fix installer.iss: `ExpandConstant('{app}')` moved inside `wpFinished` check so install directory is set before accessing it
- Add runtime_hook_tcl.py: sets TCL_LIBRARY/TK_LIBRARY env vars for frozen PyInstaller bundle
- Add hook-customtkinter.py: ensures CTK assets are bundled
- Update spec file: bundle Tcl/Tk libraries, configure hookspath and runtime_hooks
- Version bumped to 1.1.1

## Testing

- [ ] Build with PyInstaller on Windows
- [ ] Run installer, verify no CMD window and app opens correctly
- [ ] Test download from each platform