### PR TITLE
Fix crash when pre-filling YouTube Music track-name dialog

### DIFF
--- a/src/handlers/youtube_handler.py
+++ b/src/handlers/youtube_handler.py
@@ -142,10 +142,10 @@ class YouTubeHandler(BaseHandler):
                         dialog = CenteredInputDialog(
                             text="Enter a name for this track:",
                             title="YouTube Music Download",
+                            initial_value=(
+                                track_name if track_name != "YouTube Music" else None
+                            ),
                         )
-                        if track_name != "YouTube Music":
-                            dialog._entry.delete(0, "end")
-                            dialog._entry.insert(0, track_name)
 
                         if not (name := dialog.get_input()):
                             logger.info(

--- a/src/ui/dialogs/input_dialog.py
+++ b/src/ui/dialogs/input_dialog.py
@@ -4,6 +4,16 @@ from src.utils.window import WindowCenterMixin
 
 
 class CenteredInputDialog(ctk.CTkInputDialog, WindowCenterMixin):
-    def __init__(self, title: str, text: str) -> None:
+    def __init__(self, title: str, text: str, initial_value: str | None = None) -> None:
+        # CTkInputDialog builds its entry asynchronously via after(10, _create_widgets),
+        # so the entry widget does not exist yet during __init__. Store the desired
+        # initial text and apply it once the entry is actually created.
+        self._initial_value = initial_value
         super().__init__(text=text, title=title)
         self.center_window()
+
+    def _create_widgets(self) -> None:
+        super()._create_widgets()
+        if self._initial_value:
+            self._entry.delete(0, "end")
+            self._entry.insert(0, self._initial_value)


### PR DESCRIPTION
## Summary

Fixes a crash that breaks **every YouTube Music download** once metadata resolves a track title.

When a `music.youtube.com` link is added, `YouTubeHandler.show_music_name_dialog` constructs a `CenteredInputDialog` and immediately tries to pre-fill it with the fetched title via `dialog._entry`. But `CenteredInputDialog` subclasses `CTkInputDialog`, which builds its entry widget **asynchronously**:

```python
self.after(10, self._create_widgets)  # customtkinter/windows/ctk_input_dialog.py
```

So `self._entry` does not exist yet at construction time, and the access raises:

```
AttributeError: 'CenteredInputDialog' object has no attribute '_entry'
  File "src/handlers/youtube_handler.py", line 147, in show_music_name_dialog
    dialog._entry.delete(0, "end")
```

The pre-fill path runs whenever metadata returns a title (i.e. essentially always), so the dialog never opens and the download fails.

## Fix

- Add an optional `initial_value` parameter to `CenteredInputDialog` and apply it by overriding `_create_widgets`, so the prefill happens **when the entry widget actually exists** (timing-safe regardless of the `after()` delay).
- Update `YouTubeHandler` to pass `initial_value=track_name` instead of poking `_entry` at construction time.

Two-file change, no behavior change other than removing the crash. The dialog now opens pre-filled with the track title as originally intended.

## Reproduction

1. Launch the app, paste a YouTube Music URL (e.g. `https://music.youtube.com/watch?v=O1PkZaFy61Y`).
2. **Before:** the "YouTube Music Download" dialog never appears; log shows the `AttributeError` above.
3. **After:** the dialog opens with the name field pre-filled to the track title; confirming queues the audio download, which completes normally.

## Testing notes

Verified manually on macOS (customtkinter 5.2.2, Tk 9.0): the dialog builds with the entry correctly pre-filled and no exception. I did not add an automated test because the suite mocks `customtkinter`/`tkinter` via `sys.modules` (see `tests/conftest.py`) and CI runs headless, so a real-widget regression test for this path can't execute there. Happy to add one in whatever form maintainers prefer.
