### PR TITLE
Revert PR #13 from release-only main

### DIFF
--- a/src/handlers/youtube_handler.py
+++ b/src/handlers/youtube_handler.py
@@ -142,10 +142,10 @@ class YouTubeHandler(BaseHandler):
                         dialog = CenteredInputDialog(
                             text="Enter a name for this track:",
                             title="YouTube Music Download",
-                            initial_value=(
-                                track_name if track_name != "YouTube Music" else None
-                            ),
                         )
+                        if track_name != "YouTube Music":
+                            dialog._entry.delete(0, "end")
+                            dialog._entry.insert(0, track_name)
 
                         if not (name := dialog.get_input()):
                             logger.info(

--- a/src/ui/dialogs/input_dialog.py
+++ b/src/ui/dialogs/input_dialog.py
@@ -4,16 +4,6 @@ from src.utils.window import WindowCenterMixin
 
 
 class CenteredInputDialog(ctk.CTkInputDialog, WindowCenterMixin):
-    def __init__(self, title: str, text: str, initial_value: str | None = None) -> None:
-        # CTkInputDialog builds its entry asynchronously via after(10, _create_widgets),
-        # so the entry widget does not exist yet during __init__. Store the desired
-        # initial text and apply it once the entry is actually created.
-        self._initial_value = initial_value
+    def __init__(self, title: str, text: str) -> None:
         super().__init__(text=text, title=title)
         self.center_window()
-
-    def _create_widgets(self) -> None:
-        super()._create_widgets()
-        if self._initial_value:
-            self._entry.delete(0, "end")
-            self._entry.insert(0, self._initial_value)


### PR DESCRIPTION
## Why

PR #13 was accidentally merged directly into `main`. This repository uses `development` for tested feature integration and reserves `main` for releases.

## What this does

- Reverts only merge commit `3502a68` from `main`
- Restores `main` to its pre-PR #13 release state
- Does not discard the contributor's work

The timing-safe YouTube Music title prefill behavior was reviewed, tested, and merged properly into `development` through PR #18. This PR only repairs branch policy until the next release promotion from `development`.
